### PR TITLE
Update typings dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "author": "Rick Hernandez",
   "license": "MIT",
   "devDependencies": {
-    "ts-loader": "^2.0.2",
-    "typescript": "^2.2.1",
-    "typings": "^1.3.3",
-    "webpack": "^2.2.1"
+    "ts-loader": "^4.4.2",
+    "typescript": "^2.9.2",
+    "typings": "^2.1.1",
+    "webpack": "^4.14.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Breaking changes in typings upgrades have made this project produce build errors for "PropertyKey" in VS Code. Updating dev dependencies to respective versions has resolved the issue.